### PR TITLE
Zuordnen von Datensätzen zu Herausgebern

### DIFF
--- a/ckanext/dcatde/harvesters/dcatde_rdf.py
+++ b/ckanext/dcatde/harvesters/dcatde_rdf.py
@@ -6,6 +6,8 @@ DCAT-AP.de RDF Harvester module.
 import json
 import logging
 import time
+import re
+import unicodedata
 from SPARQLWrapper.SPARQLExceptions import SPARQLWrapperException
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import FOAF
@@ -36,7 +38,7 @@ CONFIG_PARAM_RESOURCES_REQUIRED = 'resources_required'
 CONFIG_PARAM_CONTRIBUTOR_ID = 'contributorID'
 CONTRIBUTOR_ID_FIELD_NAME = 'contributorID'
 RES_EXTRA_KEY_LICENSE = 'license'
-
+CONFIG_PARAM_REMOTE_ORGS = 'remote_orgs'
 
 class DCATdeRDFHarvester(DCATRDFHarvester):
     """ DCAT-AP.de RDF Harvester """
@@ -118,48 +120,51 @@ class DCATdeRDFHarvester(DCATRDFHarvester):
         base_context = {'model': model, 'session': model.Session,
                 'user': self._get_user_name()}
 
-        remote_orgs = json.loads(harvest_object.job.source.config).get('remote_orgs', None)
+        remote_orgs = self._get_remote_orgs_from_config(
+            harvest_object.job.source.config
+        )
         if remote_orgs in ('only_local', 'create'):
-                publisher_name = get_extras_field(dataset_dict, 'publisher_name')
-                if (publisher_name):
-                    publisher_name = " ".join(publisher_name.get('value').split())
+            publisher_name = get_extras_field(dataset_dict, 'publisher_name')
+            if (publisher_name):
+                publisher_name = " ".join(publisher_name.get('value').split())
 
-                # Look for the publisher by name
-                owner_org = None
+            # Look for the publisher by name
+            owner_org = None
 
-                organizations = model.Session.query(model.Group.id).filter(model.Group.state == 'active').filter(model.Group.is_organization == True).filter(model.Group.title == publisher_name).all()
+            organizations = model.Session.query(model.Group.id).filter(model.Group.state == 'active').filter(model.Group.is_organization == True).filter(model.Group.title == publisher_name).all()
 
+            if len(organizations) == 1:
+                for org in organizations:
+                    owner_org = org.id
+            if len(organizations) == 0:
+                # Look for an alternative name contained the extra values of the organization
+                organizations = model.Session.query(GroupExtra.group_id).\
+                    filter(GroupExtra.key.like('alternate_name%')).\
+                    filter(GroupExtra.value == publisher_name ).all()
                 if len(organizations) == 1:
                     for org in organizations:
-                        owner_org = org.id
-                if len(organizations) == 0:
-                    # Look for an alternative name contained the extra values of the organization
-                    organizations = model.Session.query(GroupExtra.group_id).\
-                        filter(GroupExtra.key.like('alternate_name%')).\
-                        filter(GroupExtra.value == publisher_name ).all()
+                        owner_org = org.group_id
+
+            if not owner_org:
+                if remote_orgs == 'create':
+                    org = {}
+                    org['title'] = publisher_name
+                    # slug collisions can occur if two publishers normalize to the same slug
+                    org['name'] = self._slugify(publisher_name)
+                    org['type'] = 'organization'
+                    get_action('organization_create')(base_context.copy(), org)
+                    # search for the organization just created
+                    organizations = model.Session.query(model.Group.id).filter(model.Group.state == 'active').filter(model.Group.is_organization == True).filter(model.Group.title == publisher_name).all()
+
                     if len(organizations) == 1:
-                       for org in organizations:
-                           owner_org = org.group_id
+                        for org in organizations:
+                          owner_org = org.id
+                    LOGGER.info('Organization %s has been newly created', owner_org )
+                else:
+                    # At this point a configuration of the Harvest Source should be considered if there should be an error if the publisher is missing.
+                    self._save_object_error( 'Missing publisher {0}'.format( publisher_name ), harvest_object, 'Import')
 
-                if not owner_org:
-                    if remote_orgs == 'create':
-                        org = {}
-                        org['title'] = publisher_name
-                        org['name'] = _gen_new_name(publisher_name)
-                        org['type'] = 'organization'
-                        get_action('organization_create')(base_context.copy(), org)
-                        # search for the organization just created
-                        organizations = model.Session.query(model.Group.id).filter(model.Group.state == 'active').filter(model.Group.is_organization == True).filter(model.Group.title == publisher_name).all()
-
-                        if len(organizations) == 1:
-                           for org in organizations:
-                              owner_org = org.id
-                        LOGGER.info('Organization %s has been newly created', owner_org )
-                    else:
-                        # At this point a configuration of the Harvest Source should be considered if there should be an error if the publisher is missing.
-                        self._save_object_error( 'Missing publisher {0}'.format( publisher_name ), harvest_object, 'Import')
-
-                dataset_dict['owner_org'] = owner_org
+            dataset_dict['owner_org'] = owner_org
 
     def before_update(self, harvest_object, dataset_dict, temp_dict):
         pass
@@ -246,6 +251,22 @@ class DCATdeRDFHarvester(DCATRDFHarvester):
         fallback = tk.config.get('ckanext.dcatde.harvest.default_license',
                                      'http://dcat-ap.de/def/licenses/other-closed')
         return fallback
+    
+    @staticmethod
+    def _get_remote_orgs_from_config(source_config):
+        ''' Get remote_orgs from source '''
+        if not source_config:
+            return None
+
+        return json.loads(source_config).get(CONFIG_PARAM_REMOTE_ORGS)
+
+    @staticmethod
+    def _slugify(value):
+        value = value.lower()
+        value = unicodedata.normalize("NFKD", value)
+        value = value.encode("ascii", "ignore").decode("ascii")
+        value = re.sub(r"[^a-z0-9]+", "-", value)
+        return value.strip("-")
 
     def _skip_dataset_in_triplestore(self, harvester_config, uri, graph):
         ''' Returns True if resources_required is active and dataset does not contain a distribution'''
@@ -462,7 +483,10 @@ class DCATdeRDFHarvester(DCATRDFHarvester):
         # set custom field and perform other fixes on the data
         self._amend_package(harvest_object)
         package = json.loads(harvest_object.content)
-        if package.get('owner_org') == None:
+        
+        # Ensure that the property "owner_org" is set for the dataset, if the option "remote_orgs" is set, otherwise skip the import.
+        remote_orgs = self._get_remote_orgs_from_config(harvest_object.source.config)
+        if remote_orgs in ('only_local', 'create') and package.get('owner_org') is None:
             return False
 
         import_dataset = HarvestUtils.handle_duplicates(harvest_object)


### PR DESCRIPTION
Hier ist ein erster Diskussionsstand für die Implementierung der Zuordnen von Datensätzen zu Herausgebern.

Wie beim CKAN-CKAN-Harvester wird die Konfiguration `remote_orgs` verwendet, um zu steuern, ob überhaupt eine Suche nach Herausgebern stattfinden soll und wenn ja, ob auch fehlende Herausgeber automatisch angelegt werden sollen.

Als Name wir zunächst der Titel der Organsation gesucht. Gibt es keine passende Organisation, wird in Extra-Feldern `alternate_name_x` nach weiteren Bezeichnungen einer Organisation gesucht.

Fixes #19 