### PR TITLE
Relax requirement pinning to accept higher ckanext-dcat versions

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -1,5 +1,5 @@
 ckanapi>=4
-ckanext-dcat==1.5.1
+ckanext-dcat>=1.5.1
 ckantoolkit>=0.0.7
 pycountry>=21
 python-dateutil>=2.8.2


### PR DESCRIPTION
I can't install ckanext-dcatde alongside the recently released ckanext-dcat 1.6.0 due to the strict version pinning. This PR relaxes the version pinning from a strictly pinned version to 1.5.1 and any later version.

I've tested the installation successfully on a CKAN 2.10.3 instance.

Assuming semver is used, '>=' will not ensure compatibility, but since it is used for all other requirements, I didn't want to divert from the current style. Semantically my PR is to switch to `ckanext>=1.5.1,==1.*` (or `~=1.5` if a downgrade to 1.5.0 is not a problem, but I didn't disect the history to see what was the reason for the strict 1.5.1).