### PR TITLE
Fix README regarding required resources option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ configuration parameter `ckanext.dcatde.harvest.default_license`. Add the follow
 
     ckanext.dcatde.harvest.default_license = http://dcat-ap.de/def/licenses/other-closed
 
-### Skipping datasets which does not contain any resources
-Skipping datasets which does not contain any resources can be activated by setting the optional
+### Skipping datasets which do not contain any resources
+Skipping datasets which do not contain any resources can be activated by setting the optional
 configuration parameter `resources_required` in the harvest source configuration.
-Already existent datasets will not be skipped. Add the following parameter into the harvest source
+Already existent datasets without resources will be deleted. Add the following parameter into the harvest source
 configuration:
 
     {"resources_required": true}


### PR DESCRIPTION
[Version 3.9.0](https://github.com/GovDataOfficial/ckanext-dcatde/commit/9bd9a7583dccba0602c19eeaf4caaecb07d400b3) changed the behaviour so that local datasets are deleted, but the README wasn't updated.